### PR TITLE
Fixed infinte speed bug (line 392)

### DIFF
--- a/ModularFirstPersonController/FirstPersonController/FirstPersonController.cs
+++ b/ModularFirstPersonController/FirstPersonController/FirstPersonController.cs
@@ -389,7 +389,7 @@ public class FirstPersonController : MonoBehaviour
 
                     if(isCrouched)
                     {
-                        Crouch();
+                        isCrouched = false;
                     }
 
                     if(hideBarWhenFull && !unlimitedSprint)


### PR DESCRIPTION
If you press and hold crouch, then press sprint, then release crouch, your walking speed will increase, and you can keep doing this until it breaks the game. 

The reason for this is because when sprint is pressed while crouching, it will call the Crouch() function, dividing the walk speed by the speed reduction and setting isCrouched to false. Then you release the crouch key which sets isCrouched to true, then calls Crouch() again, which divides the speed again, resulting in a net gain of speed.

The fix for this is to change line 392 from `Crouch();` to `isCrouched = false;`, and this removes the bug completely.