### PR TITLE
Fix: Set FOV back to normal when sprinting ends

### DIFF
--- a/ModularFirstPersonController/FirstPersonController/FirstPersonController.cs
+++ b/ModularFirstPersonController/FirstPersonController/FirstPersonController.cs
@@ -284,6 +284,7 @@ public class FirstPersonController : MonoBehaviour
             {
                 // Regain sprint while not sprinting
                 sprintRemaining = Mathf.Clamp(sprintRemaining += 1 * Time.deltaTime, 0, sprintDuration);
+				playerCamera.fieldOfView = Mathf.Lerp(playerCamera.fieldOfView, fov, sprintFOVStepTime * Time.deltaTime);
             }
 
             // Handles sprint cooldown 


### PR DESCRIPTION
The FOV did not get set back to normal when player stops sprinting.